### PR TITLE
modernize CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,18 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.11)
 
-project(lbfgs)
+project(lbfgs VERSION 2.3.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_FLAGS "-std=c++11")
-set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -fPIC")
+set(CMAKE_CXX_STANDARD 17)          # ensure cmake instructs compiler to use C++17
+set(CMAKE_CXX_STANDARD_REQUIRED ON) # ensure the C++ standard given before is actually used
+set(CMAKE_CXX_EXTENSIONS OFF)       # avoid compile flags of the type -std=gnu++1z added by cmake
+
+include(GNUInstallDirs)
 
 find_package(Eigen3 REQUIRED)
 
-include_directories(
-    include
-    ${EIGEN3_INCLUDE_DIRS}
-)
+option(LBFGS_BUILD_EXAMPLE "Build this library with example." ON)
 
-add_executable(${PROJECT_NAME} src/lbfgs_example.cpp)
+add_subdirectory(include)
+if(LBFGS_BUILD_EXAMPLE)
+    add_subdirectory(src)
+endif()

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(lbfgs INTERFACE)
+add_library(lbfgs::lbfgs ALIAS lbfgs)
+target_link_libraries(lbfgs INTERFACE Eigen3::Eigen)
+
+# Add the include paths to the Reaktoro target
+target_include_directories(lbfgs
+    INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>/include
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(lbfgs INTERFACE cxx_std_11)
+
+install(TARGETS lbfgs EXPORT lbfgsTargets)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers
+    PATTERN "CMakeLists.txt" EXCLUDE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(example lbfgs_example.cpp)
+target_link_libraries(example PRIVATE lbfgs::lbfgs)


### PR DESCRIPTION
I have rewritten the CMakeLists files to make them fit the modern cmake pattern. Generally, it can bring about the following advantages compared to legacy cmake:
- More user-friendly for external users, users can now link the interface library easily using cmake package manager like Fetch or CPM.
- Modulize the package so that variables and compile definitions would not populate other scopes.
- Make this project easier to extend in the future.